### PR TITLE
Continue bootstrap when brew bundle has partial failures

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Install Galaxy collections
         run: ansible-galaxy collection install -r ansible/requirements.yml
 
+      - name: Install bats
+        run: sudo apt-get update && sudo apt-get install -y bats
+
       - name: Unit — inputs well-formed
         run: ansible-playbook ansible/tests/unit/test_syntax.yml
 
@@ -33,3 +36,6 @@ jobs:
 
       - name: Unit — Brewfile parses
         run: ansible-playbook ansible/tests/unit/test_brewfile.yml
+
+      - name: Unit — bootstrap.sh
+        run: bats tests/bootstrap.bats

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,65 @@
+# CLAUDE.md
+
+Guidance for Claude Code (and humans) working in this repo.
+
+## Test-driven development
+
+This repo follows TDD. **Write the test first.**
+
+1. **Red** — Write a test that fails for the right reason (reproduces the bug
+   for fixes, asserts the new behavior for features).
+2. **Green** — Make the smallest change that turns the test green.
+3. **Refactor** — Clean up while tests stay green.
+
+Every bug fix lands with a regression test. Every behavior change lands with
+a test that would have failed before the change. The only PRs that may skip
+tests are doc-only or comment-only changes.
+
+When fixing a bug, prove the test catches it: temporarily revert the fix and
+confirm the new test fails, then re-apply the fix and confirm it passes.
+
+## Where tests live
+
+| Suite | Location | Runner |
+|---|---|---|
+| `bootstrap.sh` shell unit tests | `tests/*.bats` | `bats` |
+| Ansible playbook unit tests (Linux-friendly) | `ansible/tests/unit/*.yml` | `ansible-playbook` |
+| Full playbook + verify (macOS) | `ansible/tests/integration/` | `./run.sh` |
+
+Run locally:
+
+```sh
+bats tests/bootstrap.bats
+ansible-playbook ansible/tests/unit/test_syntax.yml
+ansible-playbook ansible/tests/unit/test_dotfiles_list.yml
+ansible-playbook ansible/tests/unit/test_brewfile.yml
+ansible/tests/integration/run.sh   # macOS only
+```
+
+CI runs all unit suites on every push/PR
+(`.github/workflows/{lint,unit-tests,bootstrap-macos,integration-macos}.yml`).
+
+## Writing `bootstrap.sh` tests
+
+`bootstrap.sh` is sourceable: `main "$@"` is guarded by `BASH_SOURCE` so tests
+can `source` the file and exercise individual functions. Stub external
+commands by prepending a `$TEST_TMP/bin` directory to `PATH`. See
+`tests/bootstrap.bats` for the pattern.
+
+## Branching
+
+- `main` — release branch; what fresh MacBooks pull via the curl one-liner.
+- `develop` — integration branch.
+- Feature branches — branch from `develop`, PR into `develop`.
+
+Never push directly to `main` or `develop`.
+
+## Sensitive changes that warrant extra care
+
+- `bootstrap.sh` runs once on a brand-new Mac with no prior dotfile state.
+  A bug here means the user's shell, dotfiles, and macOS defaults silently
+  don't get applied. Test failure paths, not just the happy path.
+- `Brewfile` changes: don't drop entries without confirming with the
+  repo owner; `update.sh` regenerates from the current system.
+- Anything under `ansible/tasks/macos_defaults.yml` changes the user's
+  desktop behavior. Prefer additive changes; document overrides.

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -163,4 +163,8 @@ main() {
   log "Done. Open a new Terminal window to pick up the new shell configuration."
 }
 
-main "$@"
+# Only execute when run directly; allow tests to source this file to
+# exercise individual functions without triggering main().
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  main "$@"
+fi

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -87,7 +87,7 @@ keep_sudo_alive() {
   fi
   log "Priming sudo (needed for Cask/MAS pkg installers)."
   sudo -v
-  ( while true; do sudo -n true; sleep 60; kill -0 "$$" 2>/dev/null || exit; done ) &
+  ( while true; do sudo -n true 2>/dev/null; sleep 60; kill -0 "$$" 2>/dev/null || exit; done ) &
   SUDO_KEEPALIVE_PID=$!
   trap 'kill "$SUDO_KEEPALIVE_PID" 2>/dev/null || true' EXIT
 }
@@ -100,7 +100,17 @@ run_brew_bundle() {
     return
   fi
   log "Running brew bundle against $DOTFILES_DIR/Brewfile."
-  brew bundle --file="$DOTFILES_DIR/Brewfile"
+  # A single failed cask/formula download (e.g. a flaky vendor CDN) makes
+  # `brew bundle` exit non-zero. Without this guard, `set -e` would abort
+  # before the Ansible playbook runs — meaning dotfile symlinks, macOS
+  # defaults, oh-my-zsh, etc. would silently never get applied. Surface
+  # the failure as a warning and let the rest of bootstrap continue;
+  # the user can re-run `brew bundle` to retry transient failures.
+  if ! brew bundle --file="$DOTFILES_DIR/Brewfile"; then
+    warn "brew bundle reported failures (often a transient cask download)."
+    warn "Continuing so the playbook still runs. Re-run later to retry:"
+    warn "  brew bundle --file=$DOTFILES_DIR/Brewfile"
+  fi
 }
 
 accept_xcode_license() {

--- a/tests/bootstrap.bats
+++ b/tests/bootstrap.bats
@@ -1,0 +1,58 @@
+#!/usr/bin/env bats
+#
+# Unit tests for bootstrap.sh shell functions. Sourced (not executed)
+# so individual functions can be exercised in isolation with stubs.
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+  TEST_TMP="$(mktemp -d)"
+  export DOTFILES_DIR="$TEST_TMP"
+  touch "$TEST_TMP/Brewfile"
+  unset CI
+
+  # shellcheck disable=SC1091
+  source "$REPO_ROOT/bootstrap.sh"
+}
+
+teardown() {
+  rm -rf "$TEST_TMP"
+}
+
+stub_brew() {
+  local exit_code="$1"
+  local stub_dir="$TEST_TMP/bin"
+  mkdir -p "$stub_dir"
+  cat > "$stub_dir/brew" <<EOF
+#!/usr/bin/env bash
+exit $exit_code
+EOF
+  chmod +x "$stub_dir/brew"
+  PATH="$stub_dir:$PATH"
+  export PATH
+}
+
+@test "run_brew_bundle: returns 0 and stays quiet when brew bundle succeeds" {
+  stub_brew 0
+  run run_brew_bundle
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"reported failures"* ]]
+}
+
+@test "run_brew_bundle: returns 0 and warns when brew bundle fails" {
+  # Regression for the fresh-Mac bootstrap abort: a single flaky cask
+  # download must not stop the script — otherwise the Ansible playbook
+  # never runs and the machine is left unconfigured.
+  stub_brew 1
+  run run_brew_bundle
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"brew bundle reported failures"* ]]
+  [[ "$output" == *"Re-run later to retry"* ]]
+}
+
+@test "run_brew_bundle: skipped entirely when CI=true" {
+  export CI=true
+  stub_brew 1
+  run run_brew_bundle
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Skipping brew bundle in CI"* ]]
+}


### PR DESCRIPTION
## Summary

A fresh-MacBook bootstrap run aborted before the Ansible playbook ran, leaving the machine without dotfile symlinks, macOS defaults, oh-my-zsh, or git identity. Root cause: a single transient cask download failure (`nvidia-geforce-now` returned `curl: (18) Transferred a partial file`) made `brew bundle` exit non-zero, and `set -euo pipefail` then killed the script before `accept_xcode_license` and `run_playbook` could run.

## Changes

- `bootstrap.sh` — `run_brew_bundle` now treats a non-zero `brew bundle` exit as a warning and continues, so the playbook (the part that actually configures the machine) always runs. The user is told to re-run `brew bundle` later to retry transient downloads.
- `bootstrap.sh` — `keep_sudo_alive` redirects `sudo -n true` stderr to `/dev/null` so a momentarily-lapsed sudo timestamp during long parallel downloads doesn't print scary `sudo: a password is required` lines mid-run.

## Reproduction

From the failing run:

```
✘ Cask nvidia-geforce-now (2.0.83.141)
Error: Download failed on Cask 'nvidia-geforce-now' with message: Download failed: ...GeForceNOW-release.dmg
curl: (18) Transferred a partial file
...
`brew bundle` failed!
```

…then the script exited. After this fix, that same run would log a warning, continue to `accept_xcode_license`, and run the playbook.

## Test plan

- [ ] Manually re-run `./bootstrap.sh` on a Mac where one cask download is forced to fail (e.g. block the nvidia CDN at the network layer); confirm the playbook still runs and dotfiles get installed.
- [ ] Re-run `./bootstrap.sh` on a Mac with all downloads healthy; confirm no behavioral change and no warnings.
- [ ] CI: `bootstrap-macos.yml` (`bootstrap.sh --check`) still passes.
- [ ] CI: lint workflows (shellcheck) still pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JhnohEuZG5zfcrAqwhtbV5)_